### PR TITLE
ES Revisions 1 - Vulf, Mid/Side Matrix

### DIFF
--- a/translatables/plugins/GHZ0024/0024.py
+++ b/translatables/plugins/GHZ0024/0024.py
@@ -5,7 +5,7 @@ ts = TranslationSet()
 
 ts.append(T(tag="ClumpLabel/text",
     text='FLIP')
-    .es('TROCAR')
+    .es('INVERTIR')
     .pt('INVERTER')
     .fr('INVERSER')
     .ja('入れ替え')

--- a/translatables/plugins/GHZVC1/0002.py
+++ b/translatables/plugins/GHZVC1/0002.py
@@ -57,7 +57,7 @@ ts.append(T(tag="ClumpLabel/text",
 
 ts.append(T(tag="ClumpLabel/text",
     text='LOFI ADV')
-    .es('LO-FI EXT')
+    .es('LOFI EXT')
     .pt('LOFI +')
     .fr('LOFI EXT')
     .ja('ローファイ詳細設定')
@@ -148,7 +148,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Crunch')
-    .es('Crocancia')
+    .es(1)
     .pt('Crocância')
     .fr(1)
     .ja('クランチ')
@@ -292,7 +292,7 @@ ts.append(T(tag="ParamLabel/text",
 ts.append(T(tag="Parameter/option",
     context="LoFiType",
     text="1980's Digital")
-    .es('Digital ochentero')
+    .es('Digital: 1980s')
     .pt('Digital: Anos 80')
     .fr('Digital Années 80')
     .ja('80年代デジタル')
@@ -306,7 +306,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="LoFiType",
     text="1990's Digital")
-    .es('Digital noventero')
+    .es('Digital: 1990s')
     .pt('Digital: Anos 90')
     .fr('Digital Années 90')
     .ja('90年代デジタル')


### PR DESCRIPTION
**Mid/Side Matrix**
-  FLIP changed to _invertir_ from _trocar_, since the primary definition of _trocar_ comes from medicine and its use to mean change sounds very, very old

**Vulf Compressor**
- Changed CRUNCH back to English, will update if I find a better Spanish translation - _Crocancia_ is not a word in Spanish, looks like it was borrowed from Portuguese
- Shortened _digital ochentero_ and _digital noventero_ 
- Fixed a hyphen discrepancy 

