### PR TITLE
ES Revisions 2 - Tiltshift, Wow, Tone Control

### DIFF
--- a/translatables/plugins/GHZ0015/0015.py
+++ b/translatables/plugins/GHZ0015/0015.py
@@ -98,7 +98,7 @@ ts.append(T(tag="ClumpLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Loudness')
-    .es('Sonoridad')
+    .es('Volumen')
     .pt('Intensidade')
     .fr('Sonie')
     .ja('ラウドネス')
@@ -111,7 +111,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Output Gain')
-    .es('Ganancia salida')
+    .es('Ganancia de Salida')
     .pt('Ganho de Saída')
     .fr('Gain de Sortie')
     .ja('アウトプットゲイン')
@@ -152,7 +152,7 @@ ts.append(T(tag="Parameter/option",
     context="TiltLoudnessMode",
     text='Auto')
     # in the sense of 'automatic'
-    .es('Automático')
+    .es(1)
     .pt('Automático')
     .fr('Automatique')
     .ja('自動')
@@ -166,7 +166,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="TiltLoudnessMode",
     text='Bass')
-    .es('Bajos')
+    .es('Graves')
     .pt('Grave')
     .fr('Grave')
     .ja('低域')
@@ -194,7 +194,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="TiltLoudnessMode",
     text='Treble')
-    .es('Altos')
+    .es('Agudos')
     .pt('Agudo')
     .fr('Aigu')
     .ja('高域')
@@ -207,7 +207,7 @@ ts.append(T(tag="Parameter/option",
 
 ts.append(T(tag="Tagline",
     text='Superior tone-shaping, from mix to master.')
-    .es('Esculpe tu tono con claridad, de la mezcla al máster.')
+    .es('Modelado de tonos sensacional, de la mezcla al máster.')
     .pt('Modelagem excelente de tonalidade, da mix à master.')
     .fr('Excellent tone-shaping, du mix au master.')
     .ja('周波数の鋭利なピックアップとトーンシェーピング')

--- a/translatables/plugins/GHZ0030/0030.py
+++ b/translatables/plugins/GHZ0030/0030.py
@@ -5,7 +5,7 @@ ts = TranslationSet()
 
 ts.append(T(tag="ClumpLabel/text",
     text='ANALOG')
-    .es('ANALÓGICO')
+    .es('ANÁLOGO')
     .pt('ANALÓGICO')
     .fr('ANALOGIQUE')
     .ja('アナログ')
@@ -18,7 +18,7 @@ ts.append(T(tag="ClumpLabel/text",
 
 ts.append(T(tag="ClumpLabel/text",
     text='MISC')
-    .es('OTROS')
+    .es(1)
     .pt('OUTROS')
     .fr('AUTRES')
     .ja('その他')
@@ -96,7 +96,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Analog Noise Gain')
-    .es('Ruido analógico')
+    .es('Ganancia de Ruido Análogo')
     .pt('Ganho do Ruído Analógico')
     .fr('Gain de Bruit Analogique')
     .ja('アナログノイズゲイン')
@@ -278,7 +278,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Smoothing')
-    .es('Suavizamiento')
+    .es('Alisado')
     .pt('Suavizar')
     .fr('Polissage')
     .ja('スムージング')
@@ -470,7 +470,7 @@ ts.append(T(tag="Parameter/option",
 
 ts.append(T(tag="Tagline",
     text='Wow, flutter, tape.')
-    .es('Wow, flutter y sonidos de cinta.')
+    .es('Wow, flutter y sonido de cinta.')
     .pt('Modulação, vibração e som de fita.')
     .fr('Wow, flutter, bande magnétique.')
     .ja('ワウ・フラッター・レコード・テープ・サチュレーション')

--- a/translatables/plugins/GHZTC1/0003.py
+++ b/translatables/plugins/GHZTC1/0003.py
@@ -5,7 +5,7 @@ ts = TranslationSet()
 
 ts.append(T(tag="ClumpLabel/text",
     text='BASS')
-    .es('BAJOS')
+    .es('GRAVE')
     .pt('GRAVE')
     .fr('GRAVES')
     .ja('低域')
@@ -31,7 +31,7 @@ ts.append(T(tag="ClumpLabel/text",
 
 ts.append(T(tag="ClumpLabel/text",
     text='HIGH CUT')
-    .es('PASA ALTOS')
+    .es('PASA BAJOS')
     .pt('CORTE AGUDO')
     .fr('COUPE-HAUT')
     .ja('ハイカット')
@@ -44,7 +44,7 @@ ts.append(T(tag="ClumpLabel/text",
 
 ts.append(T(tag="ClumpLabel/text",
     text='LOW CUT')
-    .es('PASA BAJOS')
+    .es('PASA ALTOS')
     .pt('CORTE GRAVE')
     .fr('COUPE-BAS')
     .ja('ローカット')
@@ -83,7 +83,7 @@ ts.append(T(tag="ClumpLabel/text",
 
 ts.append(T(tag="ClumpLabel/text",
     text='TREBLE')
-    .es('ALTOS')
+    .es('AGUDO')
     .pt('AGUDO')
     .fr('AIGUS')
     .ja('高域')
@@ -96,7 +96,7 @@ ts.append(T(tag="ClumpLabel/text",
 
 ts.append(T(tag="HUD/state",
     text='Left')
-    .es('Izquierdo')
+    .es('Izquierda')
     .pt('Esquerda')
     .fr('Gauche')
     .ja('左のみ')
@@ -122,7 +122,7 @@ ts.append(T(tag="HUD/state",
 
 ts.append(T(tag="HUD/state",
     text='Right')
-    .es('Derecho')
+    .es('Derecha')
     .pt('Direita')
     .fr('Droite')
     .ja('右のみ')
@@ -213,7 +213,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Linear Phase')
-    .es('Fase linear')
+    .es('Fase Linear')
     .pt('Fase Linear')
     .fr('Phase Linéaire')
     .ja('リニアフェーズ')
@@ -239,7 +239,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Processing Mode')
-    .es('Modo de procesamiento')
+    .es('Modo de Procesamiento')
     .pt('Modo de Processamento')
     .fr('Mode de Traitement')
     .ja('動作モード')
@@ -266,7 +266,7 @@ ts.append(T(tag="ParamLabel/text",
 ts.append(T(tag="Parameter/option",
     context="ProcessingMode",
     text='Left Only')
-    .es('Solo izquierdo')
+    .es('Solo Izquierda')
     .pt('Solo: Esquerda')
     .fr('Gauche Seulement')
     .ja('左のみ')
@@ -294,7 +294,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="ProcessingMode",
     text='Right Only')
-    .es('Solo derecho')
+    .es('Solo Derecha')
     .pt('Solo: Direita')
     .fr('Droite Seulement')
     .ja('右のみ')
@@ -308,7 +308,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="ProcessingMode",
     text='Side Only')
-    .es('Solo Mid')
+    .es('Solo Side')
     .pt('Solo: Meio')
     .fr('Mid Seulement')
     .ja('ミッドのみ')


### PR DESCRIPTION
**Tiltshift**
- Loudness changed from _Sonoridad_ to _Volumen_. _Sonoridad_ refers more to the tonality of a sound than intensity
- New standard: Low/High translated directly to _Bajos/Altos_, Bass/Treble translated to _Graves/Agudos_ since these terms are more musical
- Left Loudness parameter AUTO in place, since it works for Spanish too and preserves space and readability 
- Added missing 'de' in translation of 'Output Gain'
- Fixed some capitalization to match original text
- Changed tagline to be much closer to the English than the current translation and sound less awkwardly phrased

**Wow Control**
- Changed _analógico_ to _análogo_ since _análogo_ is the more widely used term (_analógico_ is mostly used in Spain, análogo is in use across Latin America)
- Left MISC as is, abbreviation also works in Spanish
- Changed translation of Smoothing to _alisado_: existing translation of _suavizamiento_ is not a word
- Added 'gain' to existing translation of Analog Noise Gain 
- Changed _sonidos_ to singular _sonido_ in tagline, using plural in that sentence sounded weird

**Tone Control**
- Changed Bass/Treble to _Graves/Agudos_ for reasons mentioned above
- Fixed mistake in filter labelling: LOW CUT was translated incorrectly as LOW PASS, HIGH CUT was translated incorrectly as HIGH PASS
- Changed all Processing Mode labels that contained 'Left' or 'Right' because the existing translation had incorrect endings (_izquierdo/derecho_ should be _izquierda/derecha_ - endings would not change to -o unless following a noun)
- Noticed that the Portuguese and French translations of _SIDE ONLY_ seem to be _MID ONLY_ (lines 312, 313)