### PR TITLE
ES Revisions 4 - Trem Control, Panpot, Faraday

### DIFF
--- a/translatables/plugins/GHZLimsat/0007.py
+++ b/translatables/plugins/GHZLimsat/0007.py
@@ -5,7 +5,7 @@ ts = TranslationSet()
 
 ts.append(T(tag="ClumpLabel/text",
     text='LINK')
-    .es('ENLACE')
+    .es('VÍNCULO')
     .pt(1)
     .fr('COUPLAGE')
     .ja('リンク')
@@ -70,7 +70,7 @@ ts.append(T(tag="ClumpLabel/text",
 
 ts.append(T(tag="ClumpLabel/text",
     text='THRESH')
-    .es('LÍMITE')
+    .es('UMBRAL')
     .pt('LIMITE')
     .fr('SEUIL')
     .ja('スレッショルド')
@@ -109,7 +109,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Auto Gain')
-    .es('Ganancia auto.')
+    .es('Ganancia Auto.')
     .pt('Ganho Autom.')
     .fr('Gain Auto')
     .ja('オートゲイン')
@@ -165,7 +165,7 @@ ts.append(T(tag="ParamLabel/text",
         Amount""")
     .es("""
         Intensidad
-        de enlace""")
+        de Vínculo""")
     .pt("""
         Intensidade
         do Link""")
@@ -188,7 +188,7 @@ ts.append(T(tag="ParamLabel/text",
         Side Gain""")
     .es("""
         Ganancia de
-        enlace de Side""")
+        Vínculo de Side""")
     .pt("""
         Ganho
         Side""")
@@ -207,7 +207,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Link Mode')
-    .es('Modo de enlace')
+    .es('Modo de Vínculo')
     .pt('Modo do Link')
     .fr('Mode de Couplage')
     .ja('リンクモード')
@@ -236,7 +236,7 @@ ts.append(T(tag="ParamLabel/text",
         Sidechain
         HPF""")
     .es("""
-        Filtro pasa altos
+        Filtro Paso Altos
         de Sidechain""")
     .pt("""
         Filtro Passa-Altas
@@ -306,7 +306,7 @@ ts.append(T(tag="ParamLabel/text",
 ts.append(T(tag="Parameter/option",
     context="LinkMode",
     text='Left/Right')
-    .es('Izquierdo/Derecho')
+    .es('Izquierda/Derecha')
     .pt('Esquerda/Direita')
     .fr('Gauche/Droite')
     .ja('左/右')

--- a/translatables/plugins/GHZPanPot/0009.py
+++ b/translatables/plugins/GHZPanPot/0009.py
@@ -57,7 +57,7 @@ ts.append(T(tag="ClumpLabel/text",
 
 ts.append(T(tag="ClumpLabel/text",
     text='PRE PANNING')
-    .es('PRE PANO')
+    .es('PRE-PANO')
     .pt('PRÉ-PAN')
     .fr('PRÉ-PAN')
     .ja('適用前設定')
@@ -83,7 +83,7 @@ ts.append(T(tag="ClumpLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Flip L/R')
-    .es('Trocar L/R')
+    .es('Invertir L/R')
     .pt('Inverter L/R')
     .fr('Inverser L/R')
     .ja('L/R入れ替え')
@@ -96,7 +96,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Left Polarity')
-    .es('Polaridad L')
+    .es('Polaridad Izquierda')
     .pt('Polaridade – Esq.')
     .fr('Polarité Gauche')
     .ja('左極')
@@ -109,7 +109,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Left Trim')
-    .es('Ajuste L')
+    .es('Ajuste Izquierdo')
     .pt('Volume – Esquerda')
     .fr('Volume Gauche')
     .ja('左トリム')
@@ -122,7 +122,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Level Pan Law')
-    .es('Ley de panoramización')
+    .es('Ley de Panoramización')
     .pt('Lei do Pan')
     .fr('Loi de Panoramique')
     .ja('パンロー')
@@ -135,7 +135,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Level Pan Vol. Comp')
-    .es('Compensar vol. de pano.')
+    .es('Compensar Vol. de Pano.')
     .pt('Compensar Nível de Pan')
     .fr('Compensation de Volume')
     .ja('パンボリューム補償')
@@ -148,7 +148,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Pan Glide Time')
-    .es('Barrida de pano.')
+    .es('Barrido de Pano.')
     .pt('Tempo de Glide do Pan')
     .fr('Temps de Balayage')
     .ja('パングライドタイム')
@@ -161,7 +161,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Right Polarity')
-    .es('Polaridad R')
+    .es('Polaridad Derecha')
     .pt('Polaridade – Dir.')
     .fr('Polarité Droite')
     .ja('右極')
@@ -174,7 +174,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Right Trim')
-    .es('Ajuste R')
+    .es('Ajuste Derecho')
     .pt('Volume – Direita')
     .fr('Volume Droit')
     .ja('右トリム')
@@ -187,7 +187,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Stereo Width')
-    .es('Amplitud estéreo')
+    .es('Amplitud Estéreo')
     .pt('Abertura do Estéreo')
     .fr('Largeur Stéréo')
     .ja('ステレオ幅')
@@ -201,7 +201,7 @@ ts.append(T(tag="ParamLabel/text",
 ts.append(T(tag="Parameter/option",
     context="FlipLR",
     text='Left | Right')
-    .es('L | R')
+    .es('Izquierda | Derecha')
     .pt('L | R')
     .fr('Gauche | Droite')
     .ja('左｜右')
@@ -215,7 +215,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="FlipLR",
     text='Right | Left')
-    .es('R | L')
+    .es('Derecha | Izquierda')
     .pt('R | L')
     .fr('Droite | Gauche')
     .ja('右｜左')
@@ -257,7 +257,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="LevelPanLaw",
     text='Stereo Balancer')
-    .es('Balance estéreo')
+    .es('Balance Estéreo')
     .pt('Equilíbrio do Estéreo')
     .fr('Équilibreur Stéréo')
     .ja('ステレオバランサー')

--- a/translatables/plugins/GHZTC1/0003.py
+++ b/translatables/plugins/GHZTC1/0003.py
@@ -31,7 +31,7 @@ ts.append(T(tag="ClumpLabel/text",
 
 ts.append(T(tag="ClumpLabel/text",
     text='HIGH CUT')
-    .es('PASA BAJOS')
+    .es('PASO BAJOS')
     .pt('CORTE AGUDO')
     .fr('COUPE-HAUT')
     .ja('ハイカット')
@@ -44,7 +44,7 @@ ts.append(T(tag="ClumpLabel/text",
 
 ts.append(T(tag="ClumpLabel/text",
     text='LOW CUT')
-    .es('PASA ALTOS')
+    .es('PASO ALTOS')
     .pt('CORTE GRAVE')
     .fr('COUPE-BAS')
     .ja('ローカット')

--- a/translatables/plugins/GHZTrem/0004.py
+++ b/translatables/plugins/GHZTrem/0004.py
@@ -31,7 +31,7 @@ ts.append(T(tag="ClumpLabel/text",
 
 ts.append(T(tag="ClumpLabel/text",
     text='MISC')
-    .es('OTROS')
+    .es(1)
     .pt('OUTROS')
     .fr('AUTRES')
     .ja('その他')
@@ -122,7 +122,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Bias')
-    .es('Curvatura')
+    .es(1)
     .pt('Inclinação')
     .fr('Tension')
     .ja('バイアス')
@@ -213,7 +213,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Stereo Phase')
-    .es('Desfase estéreo')
+    .es('Fase Estéreo')
     .pt('Fase – Estéreo')
     .fr('Phase Stéréo')
     .ja('ステレオフェーズ')
@@ -252,7 +252,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Trem Type')
-    .es('Tipo de trémolo')
+    .es('Tipo de Trémolo')
     .pt('Tipo de Tremolo')
     .fr('Type de Trémolo')
     .ja('トレムタイプ')
@@ -268,8 +268,8 @@ ts.append(T(tag="ParamLabel/text",
         Trem Volume
         Comp""")
     .es("""
-        Compensación
-        volumen""")
+        Compensar Volumen
+        de Trémolo""")
     .pt("""
         Compensar Volume
         do Tremolo""")
@@ -313,7 +313,7 @@ ts.append(T(tag="ParamLabel/text",
         Gain""")
     .es("""
         Ruido
-        de tubos""")
+        de Bulbos""")
     .pt("""
         Ganho do Ruído
         da Válvula""")
@@ -394,7 +394,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="TremType",
     text='Bass')
-    .es('Bajos')
+    .es('Graves')
     .pt('Graves')
     .fr('Graves')
     .ja('低域')
@@ -408,7 +408,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="TremType",
     text='Deep Harmonic')
-    .es('Armónico extremo')
+    .es('Armónico Profundo')
     .pt('Harmônico Profundo')
     .fr('Harmonique Profonde')
     .ja('ディープハーモニック')
@@ -492,7 +492,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="TremType",
     text='Treble')
-    .es('Altos')
+    .es('Agudos')
     .pt('Agudos')
     .fr('Aigus')
     .ja('高域')


### PR DESCRIPTION
**Across all three:** Fixed mismatched capitalization, updated terms to follow previously defined standards (i.e. analog -> análogo, bass/treble -> graves/agudos, trocar -> invertir, etc)

**Tone Control**: 
- Changed LPF/HPF filters from __pasa altos/bajos__ to __paso altos/bajos__, which appears to be more standard 

**Faraday Limiter**
- Changed threshold from _límite_ to its its technical term, _umbral_
- Changed translation of link to _vínculo_, since _enlace_ is only used when talking about links in the digital sense (internet links, mobile links, etc)
- Changed _filtro pasa altos_ to _filtro pasO altos_, in keeping with Tone Control - _pasa altos_ is a misnomer

**Panpot**
- Wrote out L, R, Left | Right and Right | Left as _Izquierda_, _Derecha_, _Izquierda | Derecha_, _Derecha | Izquierda_
- Changed _trocar_ to _invertir_ as in other plugins
- Added hyphen in _Pre-Pano_

**Trem Control**
- Left Misc section as 'Misc', since abbreviation works in Spanish as well
- Bias left the same to improve readability (_bias_ is also the Spanish term, and more correct than _curvatura_)
- Stereo phase was translated as "stereo phase offset" (_desfase estéreo_), fixed to _fase estéreo_
- Tube changed to _bulbo_, which is used across Latin America to describe tubes/tube sound in the context of audio: _tubos_ implies tunnels or literal tubes
- _Armónico extremo_ changed to _Armónico profundo_ which makes more sense (Extreme Harmonic vs. Deep Harmonic)