### PR TITLE
ES Revisions 5 - Lossy, Midside, Lohi

### DIFF
--- a/translatables/plugins/GHZ0013/0013.py
+++ b/translatables/plugins/GHZ0013/0013.py
@@ -96,7 +96,7 @@ ts.append(T(tag="ClumpLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Bass Makeup')
-    .es('Compensación bajos')
+    .es('Compensación de Graves')
     .pt('Compensar Grave')
     .fr('Gain des Graves')
     .ja('低域ゲイン補償')
@@ -109,7 +109,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Flip L/R')
-    .es('Trocar L/R')
+    .es('Invertir L/R')
     .pt('Inverter L/R')
     .fr('Inverser L/R')
     .ja('L/R入れ替え')
@@ -135,7 +135,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Input Mode')
-    .es('Modo de entrada')
+    .es('Modo de Entrada')
     .pt('Modo de Entrada')
     .fr("Mode d'Entrée")
     .ja('インプットモード')
@@ -152,7 +152,7 @@ ts.append(T(tag="ParamLabel/text",
         Mode""")
     .es("""
         Modo de
-        sonoridad""")
+        Volumen""")
     .pt("""
         Modo de
         Intensidade""")
@@ -171,7 +171,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Output Mode')
-    .es('Modo de salida')
+    .es('Modo de Salida')
     .pt('Modo de Saída')
     .fr('Mode de Sortie')
     .ja('アウトプットモード')
@@ -197,7 +197,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Stereo Width')
-    .es('Amplitud estéreo')
+    .es('Amplitud Estéreo')
     .pt('Abertura do Estéreo')
     .fr('Largeur Stéréo')
     .ja('ステレオ幅')
@@ -210,7 +210,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Strength')
-    .es('Intensidad')
+    .es('Magnitud')
     .pt('Força')
     .fr('Force')
     .ja('調節')
@@ -223,7 +223,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Width Mode')
-    .es('Modo de amplitud')
+    .es('Modo de Amplitud')
     .pt('Modo de Abertura')
     .fr('Mode de Largeur')
     .ja('幅モード')
@@ -236,7 +236,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="Parameter/option",
     text='MUTE')
-    .es('MUDO')
+    .es('1')
     .pt('MUDO')
     .fr(1)
     .ja('ミゥート')
@@ -263,7 +263,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="FlipLR",
     text='Left | Right')
-    .es('L | R')
+    .es('Izquierda | Derecha')
     .pt('L | R')
     .fr('Gauche | Droite')
     .ja('左｜右')
@@ -277,7 +277,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="FlipLR",
     text='Right | Left')
-    .es('R | L')
+    .es('Derecha | Izquierda')
     .pt('R | L')
     .fr('Droite | Gauche')
     .ja('右｜左')
@@ -291,7 +291,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="InputMode",
     text='Left | Right')
-    .es('L | R')
+    .es('Izquierda | Derecha')
     .pt('L | R')
     .fr('Gauche | Droite')
     .ja('左｜右')
@@ -333,7 +333,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="MidTiltLoudnessMode",
     text='Bass')
-    .es('Bajos')
+    .es('Graves')
     .pt('Graves')
     .fr('Grave')
     .ja('低域')
@@ -361,7 +361,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="MidTiltLoudnessMode",
     text='Treble')
-    .es('Altos')
+    .es('Agudos')
     .pt('Agudos')
     .fr('Aigu')
     .ja('高域')
@@ -403,7 +403,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="StereoWidthMode",
     text='Shuffler A')
-    .es('Barajador A')
+    .es('Modo Aleatorio A')
     .pt('Embaralhar A')
     .fr('Brouilleur A')
     .ja('シャッフルA')
@@ -417,7 +417,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="StereoWidthMode",
     text='Shuffler B')
-    .es('Barajador B')
+    .es('Modo Aleatorio B')
     .pt('Embaralhar B')
     .fr('Brouilleur B')
     .ja('シャッフルB')
@@ -431,7 +431,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="StereoWidthMode",
     text='Shuffler C')
-    .es('Barajador C')
+    .es('Modo Aleatorio C')
     .pt('Embaralhar C')
     .fr('Brouilleur C')
     .ja('シャッフルC')
@@ -458,7 +458,7 @@ ts.append(T(tag="Parameter/option",
 
 ts.append(T(tag="Tagline",
     text='Expressive stereo imaging.')
-    .es('Expresividad en la imagen estéreo.')
+    .es('Imagen estéreo expresiva.')
     .pt('Expressividade na imagem estéreo.')
     .fr('Image stéréo expressive.')
     .ja('ステレオイメージャーの集結と結合')

--- a/translatables/plugins/GHZLossy/0005.py
+++ b/translatables/plugins/GHZLossy/0005.py
@@ -18,7 +18,7 @@ ts.append(T(tag="ClumpLabel/text",
 
 ts.append(T(tag="ClumpLabel/text",
     text='LOSS')
-    .es('ARTEFACTOS')
+    .es('PÉRDIDA')
     .pt('PERDA')
     .fr('PERTE')
     .ja('ロス')
@@ -61,7 +61,7 @@ ts.append(T(tag="ParamLabel/text",
         Gain""")
     .es("""
         Ganancia
-        auto.""")
+        Auto.""")
     .pt("""
         Ganho
         Automático""")
@@ -114,7 +114,7 @@ ts.append(T(tag="ParamLabel/text",
         Threshold""")
     .es("""
         Umbral
-        de Gate""")
+        de Puerta""")
     .pt("""
         Limite
         do Gate""")
@@ -193,7 +193,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Stereo Mode')
-    .es('Modo estéreo')
+    .es('Modo Estéreo')
     .pt('Modo Estéreo')
     .fr('Mode Stéréo')
     .ja('ステレオモード')
@@ -210,7 +210,7 @@ ts.append(T(tag="ParamLabel/text",
         Decay""")
     .es("""
         Decaimiento
-        del Reverb""")
+        de Reverb""")
     .pt("""
         Decaimento
         do Reverb""")
@@ -237,7 +237,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="ParamLabel/text",
     text='Weighting')
-    .es('Ponderación')
+    .es('Peso')
     .pt('Peso')
     .fr('Poids')
     .ja('加重')
@@ -251,7 +251,7 @@ ts.append(T(tag="ParamLabel/text",
 ts.append(T(tag="Parameter/option",
     context="FilterMode",
     text='Invert')
-    .es('Invertir')
+    .es('Invert.')
     .pt('Invert.')
     .fr('Inversé')
     .ja('逆')
@@ -279,7 +279,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="LossMode",
     text='Inverse')
-    .es('Inversión')
+    .es('Inverso')
     .pt('Inverso')
     .fr('Inversée')
     .ja('逆')
@@ -293,7 +293,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="LossMode",
     text='Packet Loss')
-    .es('Pérdida de paquetes')
+    .es('Pérdida de Paquetes')
     .pt('Perda de Packets')
     .fr('Perte de Paquets')
     .ja('パケットロス')
@@ -307,7 +307,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="LossMode",
     text='Packet Repeat')
-    .es('Repetición de paquetes')
+    .es('Repetición de Paquetes')
     .pt('Repetição de Packets')
     .fr('Répétition de Paquets')
     .ja('パケットリピート')
@@ -321,7 +321,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="LossMode",
     text='Phase Jitter')
-    .es('Fluctuación de fase')
+    .es('Fluctuación de Fase')
     .pt('Flutuação de Fase')
     .fr('Jitter de Phase')
     .ja('フェーズジター')
@@ -349,7 +349,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="LossMode",
     text='Standard + Packet Loss')
-    .es('Estándar + Pérdida de paquetes')
+    .es('Estándar + Pérdida de Paquetes')
     .pt('Padrão + Perda de Packets')
     .fr('Normale + Perte de Paquets')
     .ja('普通＋パケットロス')
@@ -363,7 +363,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="LossMode",
     text='Standard + Packet Repeat')
-    .es('Estándar + Repetición de paquetes')
+    .es('Estándar + Repetición de Paquetes')
     .pt('Padrão + Repetição de Packets')
     .fr('Normale + Répétition de Paquets')
     .ja('普通＋パケットリピート')
@@ -377,7 +377,7 @@ ts.append(T(tag="Parameter/option",
 ts.append(T(tag="Parameter/option",
     context="StereoMode",
     text='Joint Stereo')
-    .es('Estéreo en conjunto')
+    .es('Estéreo Conjunto')
     .pt('Estéreo Somado')
     .fr('Stéréo Combiné')
     .ja('ジョイントステレオ')
@@ -474,7 +474,7 @@ ts.append(T(tag="Parameter/option",
 
 ts.append(T(tag="Tagline",
     text='Lossy artifacts, on demand.')
-    .es('Fábrica de artefactos digitales.')
+    .es('Artefactos de compresión, bajo demanda.')
     .pt('Artefatos digitais, à disposição.')
     .fr('Artefacts numériques, à la demande.')
     .ja('デジタル・サウンド・アート・ファクトリー')

--- a/translatables/plugins/GHZSweep/0006.py
+++ b/translatables/plugins/GHZSweep/0006.py
@@ -68,8 +68,8 @@ ts.append(T(tag="ParamLabel/text",
         Filter
         Glide Time""")
     .es("""
-        Barrida
-        de filtro""")
+        Tiempo de
+        Barrido de Filtro""")
     .pt("""
         Tempo de
         Glide do Filtro""")
@@ -112,7 +112,7 @@ ts.append(T(tag="ParamLabel/text",
         Lim/Sat
         Auto Gain""")
     .es("""
-        Ganancia automática
+        Ganancia Auto.
         Lim./Sat.""")
     .pt("""
         Compensar Ganho
@@ -145,7 +145,7 @@ ts.append(T(tag="ParamLabel/text",
         Lim/Sat
         Stereo Link""")
     .es("""
-        Link estéreo
+        Vínculo Estéreo
         Lim./Sat.""")
     .pt("""
         Link Estéreo
@@ -227,7 +227,7 @@ ts.append(T(tag="ParamLabel/text",
 
 ts.append(T(tag="Tagline",
     text='Filter sweeps: lo, hi, & anywhere in between.')
-    .es('Barridas de filtro: altos, bajos y entre medio.')
+    .es('Barridos de filtro: altos, bajos y entre medio.')
     .pt('Varreduras de filtro: grave, agudo e tudo que há no meio.')
     .fr("Balayages de filtres: bas, haut, et tout l'entre-deux.")
     .ja('極細繊維で紡いだ6.0dB~96dBのフィルター')


### PR DESCRIPTION
Across all three: Fixed mismatched capitalization, updated terms to follow previously defined standards (i.e. analog -> análogo, bass/treble -> graves/agudos, trocar -> invertir, etc)

**Midside**
- _Modo de sonoridad_ changed to _Modo de Volumen_ since _sonoridad_ refers more to the acoustic qualities of a sound than its intensity or loudness
- Strength translated to _magnitud_, since _intensidad_ is already being used across all plugins to mean 'amount'
- MUTE changed back to English. The word _MUDO_ refers specifically to (and only to) a person, just as 'mute' can in English, and is equally outdated. Spanish does not have an easily recognized word when referring to the mute function, and it's often referred to in English.
- L, R changed to Izquierda, Derecha wherever appearing
- _Barajador A, B, C_ changed to _Modo Aleatorio A, B, C_ since the verb 'barajear' means shuffling almost exclusively in the sense of shuffling a deck of cards
- Tagline was worded strangely, changed it to mirror the English exactly: _Imagen estéreo expresiva._

**Lossy**
- Changed translation of LOSS from _ARTEFACTOS_ (Artifacts) to _PÉRDIDA_ (Loss)
- Translated 'gate' as _puerta_
- Less correct use of _del_ changed to _Decaimiento de Reverb_
- Weighting translated as _Peso_ (Weight) - existing translation _ponderacón_ means weighting in the statistical sense but is not very widely used outside of statistics, and would be more likely to be read as 'pondering'
- _Inversión_ changed to _inverso_ (makes more sense to have the adjective as the parameter instead of the noun)
- Unnecessary _en_ in _Estéreo en conjunto_ removed - proper term is _estéreo conjunto_
- Tagline changed from "Factory of lossy artefacts" to reflect English tagline

**Lohi**
- 'time' added into translation of Filter Glide Time
- _Automática_ abbreviated in translation of Lim/Sat Auto Gain for better readability
- Link translated as _Vínculo_ rather than being kept in English
- Fixed wrong ending in tagline (_barridas_ -> _barridos_)